### PR TITLE
Bug fix with using passfile and added ask on n consecutive locked accounts.

### DIFF
--- a/Talon.go
+++ b/Talon.go
@@ -285,8 +285,11 @@ func main() {
 		var counter float64
 		counter = 0
 		var username string
+		var pwd string
 		// Use previous main function but iterate through passwords and automate stuff
-		for _, pwd := range passwords {
+		//		for _, pwd := range passwords {
+		for p := 0; p < len(passwords); p++ {
+			pwd = passwords[p]
 			printDebug("This is the current value of counter: %f\n", counter)
 			if counter < opt.attempts {
 				fmt.Print(time.Now().Format("01-02-2006 15:04:05: "))

--- a/Talon.go
+++ b/Talon.go
@@ -288,10 +288,10 @@ func main() {
 		var pwd string
 		// Use previous main function but iterate through passwords and automate stuff
 		//		for _, pwd := range passwords {
-		for p := 0; p <= len(passwords); p++ {
-			pwd = passwords[p]
+		for p := 0; p < len(passwords); p++ {
 			printDebug("This is the current value of counter: %f\n", counter)
 			if counter < opt.attempts {
+				pwd = passwords[p]
 				fmt.Print(time.Now().Format("01-02-2006 15:04:05: "))
 				fmt.Printf("Using password: %s\n", pwd)
 				domain := strings.ToUpper(opt.domain)
@@ -351,6 +351,7 @@ func main() {
 				time.Sleep(time.Duration(opt.lockout) * time.Minute)
 				color.Unset()
 				counter = 0
+				p--
 			}
 		}
 	}

--- a/Talon.go
+++ b/Talon.go
@@ -276,6 +276,7 @@ func main() {
 				x = 0
 			} else {
 				x++
+				err = 0
 			}
 		}
 	}
@@ -295,7 +296,9 @@ func main() {
 				err := 0
 				rand.Seed(time.Now().Unix())
 				lenServices := len(services) - 1
-				for _, username := range usernames {
+//				for _, username := range usernames {
+				for i := i < len(usernames); i++ {
+					username = usernames[i]
 					n := 0
 					if opt.hostfile != "" {
 						n = rand.Int() % (len(hosts) - 1)
@@ -310,6 +313,9 @@ func main() {
 					fmt.Println(result)
 					if strings.Contains(result, "User's Account Locked") && opt.enum != true {
 						err++
+						usernames[i] = usernames[len(usernames)-1]
+						usernames = usernames[:len(usernames)-1]
+						i--
 						if err == int(opt.lockerr) {
 							reader := bufio.NewReader(os.Stdin)
 							fmt.Printf("[*] %d Consecutive account lock out(s) detected - Do you want to continue.[y/n]: ", err)
@@ -329,6 +335,7 @@ func main() {
 						x = 0
 					} else {
 						x++
+						err = 0
 					}
 				}
 				counter++
@@ -473,3 +480,91 @@ func (k KERB) Login() (string, string, error) {
 	forfile := fmt.Sprintf("%s %s %s\\%s:%s = %s", ("[+] "), k.Host, k.User.Domain, k.User.Name, k.User.Password, ("Success"))
 	return result, forfile, nil
 }
+
+
+
+
+I have an additional issue (not pertaining to the above. I can create another thread if needed. Now I am trying to fix functionality in the program. I let it run last night on a client and it worked great except this morning I noticed that when it stopped it did not iterate through the final password and I can't see the logic of where it is failing. It hit the timeout period, waited then did not utilize the last password.
+
+Current end
+[-]  10.1.16.55 [redacted]:stewart145 = Failed
+[-]  10.1.16.56 [redacted]:stewart145 = Failed
+[-]  10.1.16.55 [redacted]:stewart145 = Failed
+
+Hit timeout period - Sleeping for 61 minutes...
+Will resume at 12-08-2022 18:46:37
+
+It should then iterate across the final password. The final password in the list is Truebell145
+
+Here is the code currently (the error was before I added the removal of usernames[i] functionality, and I am not removing passwords at all. I just don't want to waste time each time spraying a username that is already known to be locked.
+    if opt.pass == "" && opt.passfile != "" {
+        var counter float64
+        counter = 0
+        // Use previous main function but iterate through passwords and automate stuff
+        for _, pwd := range passwords {
+            printDebug("This is the current value of counter: %f\n", counter)
+            if counter < opt.attempts {
+                fmt.Print(time.Now().Format("01-02-2006 15:04:05: "))
+                fmt.Printf("Using password: %s\n", pwd)
+                domain := strings.ToUpper(opt.domain)
+                printDebug("Domain %v\tUsernames %v\tPasswords %v\tHosts %v\tServices %v\n", domain, usernames, pwd, hosts, services)
+                x := 0
+                err := 0
+                rand.Seed(time.Now().Unix())
+                lenServices := len(services) - 1
+//                for _, username := range usernames {
+                for i := i < len(usernames); i++ {
+                    username = usernames[i]
+                    n := 0
+                    if opt.hostfile != "" {
+                        n = rand.Int() % (len(hosts) - 1)
+                    }
+                    if hosts[n] == "" {
+                        return
+                    }
+                    sleep := opt.sleep
+                    time.Sleep(time.Duration(sleep) * time.Second)
+                    auth := setup(services[x], hosts[n], domain, username, pwd, opt.enum)
+                    result, forfile, _ := auth.Login()
+                    fmt.Println(result)
+                    if strings.Contains(result, "User's Account Locked") && opt.enum != true {
+                        err++
+                        usernames[i] = usernames[len(usernames)-1]
+                        usernames = usernames[:len(usernames)-1]
+                        i--
+                        if err == int(opt.lockerr) {
+                            reader := bufio.NewReader(os.Stdin)
+                            fmt.Printf("[*] %d Consecutive account lock out(s) detected - Do you want to continue.[y/n]: ", err)
+                            text, _ := reader.ReadString('\n')
+                            if strings.Contains(text, "y") {
+                                err = 0
+                                continue
+                            }
+                            log.Fatal("Shutting down")
+                        }
+                    }
+                    if opt.outFile != "" {
+                        forfile = forfile + "\n"
+                        writefile(opt.outFile, forfile)
+                    }
+                    if lenServices == x {
+                        x = 0
+                    } else {
+                        x++
+                        err = 0
+                    }
+                }
+                counter++
+            } else { //Timeout for the period defined
+                // Printing output with color because why not
+                color.Set(color.FgYellow, color.Bold)
+                fmt.Printf("\nHit timeout period - Sleeping for %v minutes...\n", opt.lockout)
+                fmt.Printf("Will resume at %s", time.Now().Add(time.Duration(opt.lockout)*time.Minute).Format("01-02-2006 15:04:05"))
+                time.Sleep(time.Duration(opt.lockout) * time.Minute)
+                color.Unset()
+                counter = 0
+            }
+        }
+    }
+
+Can you or anyone else identify the issue? From what I am seeing it should still iterate on the last password in the list. but it doesn't.

--- a/Talon.go
+++ b/Talon.go
@@ -288,7 +288,7 @@ func main() {
 		var pwd string
 		// Use previous main function but iterate through passwords and automate stuff
 		//		for _, pwd := range passwords {
-		for p := 0; p < len(passwords); p++ {
+		for p := 0; p <= len(passwords); p++ {
 			pwd = passwords[p]
 			printDebug("This is the current value of counter: %f\n", counter)
 			if counter < opt.attempts {


### PR DESCRIPTION
@Tylous,

As discussed in https://github.com/optiv/Talon/issues/4, I added functionality with a new switch called -LockErr that accepts a float and locks on n consecutive locked accounts. This prevents them from being asked each time. 

I also altered the flow a little bit so that if a locked account is found (when using passfile), the account is removed for usernames[] and is no longer tested against to prevent repetitively testing the same locked account. 

I also identified a bug in the original code each time opt.attempts were triggered and the time waited, it skipped that password and moved on to the next password after the time. I corrected this by altering it from a range loop to a traditional C++ style loop and de-incrementing the password counter when hit to use the prior password that would have been skipped. 

I could clean the code up some if you would like. If I altered your original, I tried to keep it as a comment and then add my section below to prevent messing it up. 