### PR TITLE
Replace LDAP module

### DIFF
--- a/Talon.go
+++ b/Talon.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/jcmturner/gokrb5.v7/client"
 	"gopkg.in/jcmturner/gokrb5.v7/config"
 	"gopkg.in/jcmturner/gokrb5.v7/iana/etypeID"
-	"gopkg.in/ldap.v2"
+	"github.com/go-ldap/ldap/v3"
 )
 
 var (


### PR DESCRIPTION
With the LDAPv2 module I get the error `ldap: recovered panic in processMessages: unaligned 64-bit atomic operation` under a 32 bit ARM Linux. After changing to the LDAPv3 module, the LDAP mode works under 32 bit ARM.

I have also tested the LDAPv3 module under Linux/amd64 and it still works there.